### PR TITLE
This PR adds a new topic to publish the high-level velocities of the B1

### DIFF
--- a/src/DriverUnitreeB1.cpp
+++ b/src/DriverUnitreeB1.cpp
@@ -1,24 +1,26 @@
-/**
-(C) Copyright 2024-2025 Adorno-Lab software developments
-
-    This file is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
-
-    This file is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Lesser General Public License for more details.
-
-    You should have received a copy of the GNU Lesser General Public License.
-    If not, see <http://www.gnu.org/licenses/>.
-
-Contributors:
-
-1. Juan Jose Quiroz Omana (juanjose.quirozomana@manchester.ac.uk)
-        - Responsible for the original implementation.
-*/
+/*
+# (C) Copyright 2024-2025 Adorno-Lab software developments
+#
+#    This file is part of sas_robot_driver_unitree_b1.
+#
+#    This is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Lesser General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This software is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Lesser General Public License for more details.
+#
+#    You should have received a copy of the GNU Lesser General Public License
+#    along with this software.  If not, see <https://www.gnu.org/licenses/>.
+#
+# ################################################################
+#
+#   Author: Juan Jose Quiroz Omana, email: juanjose.quirozomana@manchester.ac.uk
+#
+# ################################################################*/
 
 #include "DriverUnitreeB1.hpp"
 #include <unitree_legged_sdk/unitree_legged_sdk.h>
@@ -696,6 +698,26 @@ VectorXd DriverUnitreeB1::get_mobile_platform_configuration_from_IMU_pose() cons
 
 
 /**
+ * @brief DriverUnitreeB1::get_high_level_angular_velocity returns the angular velocities when in High level mode
+ * @return The angular velocity (yaw_speed*k_)
+ */
+
+DQ DriverUnitreeB1::get_high_level_angular_velocity() const
+{
+    return high_level_angular_velocity_;
+}
+
+/**
+ * @brief DriverUnitreeB1::get_high_level_linear_velocity returns the linear velocities when in High level mode
+ * @return The planar joint velocties (x_dot*i_ + y_dot*j_)
+ */
+DQ DriverUnitreeB1::get_high_level_linear_velocity() const
+{
+    return high_level_linear_velocity_;
+}
+
+
+/**
  * @brief DriverUnitreeB1::set_high_level_forward_speed sets the target forward speed of the holonomic mobile platform.
  * @param forward_speed The desired forward speed. This method is used when the driver is set in high-level.
  */
@@ -941,6 +963,10 @@ void DriverUnitreeB1::_update_data_from_robot_state()
                              impl_->high_state_.position.at(2)*k_;
         body_height_ = impl_->high_state_.bodyHeight;
         current_high_level_mode_ = high_level_mode_map_inv_.at(impl_->high_state_.mode);
+
+        high_level_linear_velocity_  = impl_->high_state_.velocity.at(0)*i_+
+                                       impl_->high_state_.velocity.at(1)*j_;
+        high_level_angular_velocity_ = impl_->high_state_.velocity.at(2)*k_;
 
         //high_state_.yawSpeed;
         //high_state_.velocity;

--- a/src/DriverUnitreeB1.cpp
+++ b/src/DriverUnitreeB1.cpp
@@ -966,10 +966,10 @@ void DriverUnitreeB1::_update_data_from_robot_state()
 
         high_level_linear_velocity_  = impl_->high_state_.velocity.at(0)*i_+
                                        impl_->high_state_.velocity.at(1)*j_;
-        high_level_angular_velocity_ = impl_->high_state_.velocity.at(2)*k_;
 
-        //high_state_.yawSpeed;
-        //high_state_.velocity;
+        // this value impl_->high_state_.velocity.at(2)*k_ is not working. Therefore, I extracted the angular
+        // velocity from yawSpeed.
+        high_level_angular_velocity_ = impl_->high_state_.yawSpeed*k_;
     }
 }
 

--- a/src/DriverUnitreeB1.hpp
+++ b/src/DriverUnitreeB1.hpp
@@ -1,23 +1,26 @@
-/**
-(C) Copyright 2024-2025 Adorno-Lab software developments
-
-    This file is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
-
-    This file is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Lesser General Public License for more details.
-
-    You should have received a copy of the GNU Lesser General Public License.
-    If not, see <http://www.gnu.org/licenses/>.
-
-Contributors:
-
-1. Juan Jose Quiroz Omana (juanjose.quirozomana@manchester.ac.uk)
-        - Responsible for the original implementation.
+/*
+# (C) Copyright 2024-2025 Adorno-Lab software developments
+#
+#    This file is part of sas_robot_driver_unitree_b1.
+#
+#    This is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Lesser General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This software is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Lesser General Public License for more details.
+#
+#    You should have received a copy of the GNU Lesser General Public License
+#    along with this software.  If not, see <https://www.gnu.org/licenses/>.
+#
+# ################################################################
+#
+#   Author: Juan Jose Quiroz Omana, email: juanjose.quirozomana@manchester.ac.uk
+#
+# ################################################################
 */
 
 #pragma once
@@ -145,6 +148,9 @@ private:
     DQ odometry_position_{0};
     double body_height_{0};
 
+    DQ high_level_linear_velocity_{0};
+    DQ high_level_angular_velocity_{0};
+
 
     void _update_data_from_robot_state();
 
@@ -250,6 +256,8 @@ public:
     DQ get_IMU_accelerometer() const;
     DQ get_IMU_pose() const;
     VectorXd get_mobile_platform_configuration_from_IMU_pose() const;
+    DQ get_high_level_angular_velocity() const;
+    DQ get_high_level_linear_velocity() const;
 
     DQ get_odometry_position() const;
     double get_body_height() const;

--- a/src/unitree_b1_node.hpp
+++ b/src/unitree_b1_node.hpp
@@ -1,20 +1,20 @@
 /*
-# Copyright (c) 2024 Juan Jose Quiroz Omana
+# (C) Copyright 2024-2025 Adorno-Lab software developments
 #
 #    This file is part of sas_robot_driver_unitree_b1.
 #
-#    sas_robot_driver_kuka is free software: you can redistribute it and/or modify
+#    This is free software: you can redistribute it and/or modify
 #    it under the terms of the GNU Lesser General Public License as published by
 #    the Free Software Foundation, either version 3 of the License, or
 #    (at your option) any later version.
 #
-#    sas_robot_driver_kuka is distributed in the hope that it will be useful,
+#    This software is distributed in the hope that it will be useful,
 #    but WITHOUT ANY WARRANTY; without even the implied warranty of
 #    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #    GNU Lesser General Public License for more details.
 #
 #    You should have received a copy of the GNU Lesser General Public License
-#    along with sas_robot_driver_kuka.  If not, see <https://www.gnu.org/licenses/>.
+#    along with this software.  If not, see <https://www.gnu.org/licenses/>.
 #
 # ################################################################
 #
@@ -29,6 +29,7 @@
 #include <thread>
 #include <rclcpp/rclcpp.hpp>
 #include <geometry_msgs/msg/pose_stamped.hpp>
+#include <geometry_msgs/msg/twist_stamped.hpp>
 #include <std_msgs/msg/float64_multi_array.hpp>
 #include <std_msgs/msg/int32_multi_array.hpp>
 #include <sensor_msgs/msg/joint_state.hpp>
@@ -79,6 +80,7 @@ private:
     Publisher<sensor_msgs::msg::Imu>::SharedPtr publisher_IMU_state_;
     Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr publisher_pose_state_;
     Publisher<sensor_msgs::msg::BatteryState>::SharedPtr publisher_battery_state_;
+    Publisher<geometry_msgs::msg::TwistStamped>:: SharedPtr publisher_high_level_velocities_state_;
 
     Subscription<std_msgs::msg::Float64MultiArray>::SharedPtr subscriber_target_holonomic_velocities_;
 
@@ -96,6 +98,7 @@ protected:
 
     void _read_joint_states_and_publish();
     void _read_imu_state_and_publish();
+    void _read_twist_state_and_publish();
     void _read_battery_state();
     bool _should_shutdown() const;
     void _set_target_velocities_from_subscriber();


### PR DESCRIPTION
This PR adds the topic `/sas_b1/b1_1/get/twist`, which publishes the planar joint (i.e., x_dot, y_dot, phi_dot)  velocities of the B1 robot.



